### PR TITLE
Add people functions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,32 +1,7 @@
-<!--- Provide a general summary of the issue in the Title above -->
+## Motivation
 
-## Expected Behavior
-<!--- If you're describing a bug, tell us what should happen -->
-<!--- If you're suggesting a change/improvement, tell us how it should work -->
-
-## Current Behavior
-<!--- If describing a bug, tell us what happens instead of the expected behavior -->
-<!--- If suggesting a change/improvement, explain the difference from expected behavior -->
+WHY is this change necessary
 
 ## Possible Solution
-<!--- Not obligatory, but suggest a fix/reason for the bug, -->
-<!--- or ideas how to implement the addition or change -->
 
-## Steps to Reproduce (for bugs)
-<!--- Provide a link to a live example, or an unambiguous set of steps to -->
-<!--- reproduce this bug. Include code to reproduce, if relevant -->
-1.
-2.
-3.
-4.
-
-## Context
-<!--- How has this issue affected you? What are you trying to accomplish? -->
-<!--- Providing context helps us come up with a solution that is most useful in the real world -->
-
-## Your Environment
-<!--- Include as many relevant details about the environment you experienced the bug in -->
-
-- Elixir version (elixir -v):
-- Mxpanel version (mix deps):
-- Operating system:
+HOW this necessity can be solved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Examples section to readme.
+- `Mxpanel.create_alias/3`.
+- `Mxpanel.People.append_item/5`.
+- `Mxpanel.People.delete/3`.
+- `Mxpanel.People.increment/5`.
+- `Mxpanel.People.remove_item/5`.
+- `Mxpanel.People.set/4`.
+- `Mxpanel.People.set_once/4`.
+- `Mxpanel.People.unset/4`.
+
 ## Changed
 
+- Support custom `:ip` and `:time` for track events.
+- Simplify issue template.
 - Improve `:token` validation, to allow `nil` values when inactive.
 
 ## [0.2.0] - 2021-06-21

--- a/README.md
+++ b/README.md
@@ -27,34 +27,66 @@ def deps do
 end
 ```
 
-## Usage
-
-### Track event
+## Examples
 
 ```elixir
-client = %Mxpanel.Client{token: "mixpanel project token"}
-event = Mxpanel.Event.new("signup", "123")
+# Create a client struct with your project token
+client = %Mxpanel.Client{token: "<mixpanel project token>"}
 
+# track an event
+event = Mxpanel.Event.new("signup", "billybob")
 Mxpanel.track(client, event)
-```
 
-### Enqueue an event
+# track an event with optional properties
+event = Mxpanel.Event.new("signup", "billybob", %{"Favourite Color" => "Red"})
+Mxpanel.track(client, event)
 
-1. Add to your supervision tree:
+# set an IP address to get automatic geolocation info
+event = Mxpanel.Event.new("signup", "billybob", %{}, ip: "72.229.28.185")
+Mxpanel.track(client, event)
 
-```elixir
-{Mxpanel.Batcher, name: MyApp.Batcher, token: "mixpanel project token"}
-```
+# track an event with a specific timestamp
+event = Mxpanel.Event.new("signup", "billybob", %{}, time: System.os_time(:second) - 60)
+Mxpanel.track(client, event)
 
-2. Call `track_later/2`:
-
-```elixir
-event = Mxpanel.Event.new("signup", "123")
-
+# track an event in background, the event will be buffered, and later sent in batches
+Mxpanel.Batcher.start_link(name: MyApp.Batcher, token: "<mixpanel project token>")
+event = Mxpanel.Event.new("signup", "billybob")
 Mxpanel.track_later(MyApp.MxpanelBatcher, event)
-```
 
-3. The event will be buffered, and later sent in batch to the Mixpanel API.
+# Create an alias for an existing distinct id
+Mxpanel.create_alias(client, "distinct_id", "your_alias")
+
+# create or update a user in Mixpanel Engage
+properties = %{"Address" => "1313 Mockingbird Lane", "Birthday" => "1948-01-01"}
+Mxpanel.People.set(client, "billybob", properties)
+
+# create or update a user in Mixpanel Engage without altering $last_seen
+Mxpanel.People.set(client, "billybob", %{plan: "premium"}, ignore_time: true)
+
+# set a user profile's IP address to get automatic geolocation info
+Mxpanel.People.set(client, "billybob", %{plan: "premium"}, ip: "72.229.28.185")
+
+# set properties on a user, don't override
+properties = %{"First login date" => "2013-04-01T13:20:00"}
+Mxpanel.People.set_once(client, "billybob", properties)
+
+# removes the properties
+Mxpanel.People.unset(client, "billybob", ["Address", "Birthday"])
+
+# increment a numeric property
+Mxpanel.People.increment(client, "billybob", "Number of Logins", 12)
+
+# append value to a list
+Mxpanel.People.append_item(client, "billybob", "Items purchased", "socks")
+
+# remove value from a list
+Mxpanel.People.remove_item(client, "billybob", "Items purchased", "t-shirt")
+
+# delete a user
+Mxpanel.People.delete(client, "billybob")
+
+```
 
 ## Telemetry
 

--- a/lib/mxpanel/api.ex
+++ b/lib/mxpanel/api.ex
@@ -1,0 +1,27 @@
+defmodule Mxpanel.API do
+  @moduledoc false
+
+  def request(client, endpoint, data) do
+    encoded_data =
+      data
+      |> Mxpanel.json_library().encode!()
+      |> Base.encode64()
+
+    {http_mod, http_opts} = client.http_client
+
+    url = client.base_url |> URI.parse() |> Map.put(:path, endpoint) |> URI.to_string()
+    headers = [{"Accept", "text/plain"}, {"Content-Type", "application/x-www-form-urlencoded"}]
+    encoded_body = URI.encode_query(%{data: encoded_data})
+
+    case apply(http_mod, :request, [:post, url, headers, encoded_body, http_opts]) do
+      {:ok, %{status: 200, body: "1"}} ->
+        :ok
+
+      {:ok, response} ->
+        {:error, response}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end

--- a/lib/mxpanel/batcher.ex
+++ b/lib/mxpanel/batcher.ex
@@ -53,7 +53,7 @@ defmodule Mxpanel.Batcher do
     ],
     http_client: [
       type: {:custom, __MODULE__, :validate_http_client, []},
-      doc: "HTTP client used by the Batcher",
+      doc: "HTTP client used by the Batcher.",
       default: {Mxpanel.HTTPClient.HackneyAdapter, []}
     ],
     pool_size: [
@@ -96,7 +96,7 @@ defmodule Mxpanel.Batcher do
     ],
     debug: [
       type: :boolean,
-      doc: "Enable debug logging",
+      doc: "Enable debug logging.",
       default: false
     ]
   ]

--- a/lib/mxpanel/client.ex
+++ b/lib/mxpanel/client.ex
@@ -12,7 +12,8 @@ defmodule Mxpanel.Client do
 
   ## Custom HTTP client
 
-  You can switch the default HTTP client which uses [hackney](https://github.com/benoitc/hackney) underneath
+  You can switch the default HTTP client (`Mxpanel.HTTPClient.HackneyAdapter`)
+  which uses [hackney](https://github.com/benoitc/hackney) underneath
   by defining a different implementation by setting the `:http_client` option:
 
       %Mxpanel.Client{http_client: {MyCustomHTTPClient, []}, token: "token"}

--- a/lib/mxpanel/event.ex
+++ b/lib/mxpanel/event.ex
@@ -38,7 +38,7 @@ defmodule Mxpanel.Event do
   #{NimbleOptions.docs(@opts_schema)}
 
   """
-  @spec new(String.t(), String.t(), map()) :: t()
+  @spec new(String.t(), String.t(), map(), Keyword.t()) :: t()
   def new(name, distinct_id, additional_properties \\ %{}, opts \\ [])
       when is_binary(name) and is_binary(distinct_id) and is_map(additional_properties) do
     opts = validate_options!(opts)

--- a/lib/mxpanel/event.ex
+++ b/lib/mxpanel/event.ex
@@ -3,30 +3,53 @@ defmodule Mxpanel.Event do
   Struct representing a Mixpanel Event
   """
 
-  defstruct [:name, :insert_id, :time, :distinct_id, :additional_properties]
+  @opts_schema [
+    time: [
+      type: :pos_integer,
+      doc: "Specific timestamp in seconds of the event. Defaults to `System.os_time(:second)`."
+    ],
+    ip: [
+      type: :string,
+      doc: "IP address to get automatic geolocation info."
+    ]
+  ]
+
+  defstruct [:name, :insert_id, :time, :distinct_id, :additional_properties, :ip]
 
   @type t :: %__MODULE__{
           name: String.t(),
           insert_id: String.t(),
           time: integer(),
-          additional_properties: %{}
+          additional_properties: %{},
+          ip: nil | String.t()
         }
 
   @doc """
   Create a new event.
 
+      Mxpanel.Event.new("signup", "13793")
       Mxpanel.Event.new("signup", "13793", %{"Favourite Color" => "Red"})
+      Mxpanel.Event.new("signup", "13793", %{}, ip: "72.229.28.185")
+      Mxpanel.Event.new("signup", "13793", %{}, time: 1624811298)
+
+
+  ## Options
+
+  #{NimbleOptions.docs(@opts_schema)}
 
   """
   @spec new(String.t(), String.t(), map()) :: t()
-  def new(name, distinct_id, additional_properties \\ %{})
-      when is_binary(name) and is_binary(distinct_id) do
+  def new(name, distinct_id, additional_properties \\ %{}, opts \\ [])
+      when is_binary(name) and is_binary(distinct_id) and is_map(additional_properties) do
+    opts = validate_options!(opts)
+
     %__MODULE__{
       name: name,
       distinct_id: distinct_id,
       insert_id: unique_insert_id(),
-      time: System.os_time(:second),
-      additional_properties: additional_properties
+      time: Keyword.get(opts, :time, System.os_time(:second)),
+      additional_properties: additional_properties,
+      ip: Keyword.get(opts, :ip)
     }
   end
 
@@ -44,8 +67,29 @@ defmodule Mxpanel.Event do
 
     %{
       "event" => event.name,
-      "properties" => Map.merge(event.additional_properties, properties)
+      "properties" =>
+        event.additional_properties
+        |> Map.merge(properties)
+        |> maybe_put("ip", event.ip, fn ip -> is_binary(ip) end)
     }
+  end
+
+  defp validate_options!(opts) do
+    case NimbleOptions.validate(opts, @opts_schema) do
+      {:ok, opts} ->
+        opts
+
+      {:error, %NimbleOptions.ValidationError{message: message}} ->
+        raise ArgumentError, message
+    end
+  end
+
+  defp maybe_put(map, key, value, condition) do
+    if condition.(value) do
+      Map.put(map, key, value)
+    else
+      map
+    end
   end
 
   defp unique_insert_id do

--- a/lib/mxpanel/http_client/hackney_adapter.ex
+++ b/lib/mxpanel/http_client/hackney_adapter.ex
@@ -1,6 +1,6 @@
 defmodule Mxpanel.HTTPClient.HackneyAdapter do
   @moduledoc """
-  Adapter for [hackney](https://github.com/benoitc/hackney).
+  `Mxpanel.HTTPClient` adapter for [hackney](https://github.com/benoitc/hackney).
 
   Remember to add `{:hackney, "~> 1.17"}` to dependencies. Also, you need to
   recompile mxpanel after adding the `:hackney` dependency:
@@ -9,10 +9,6 @@ defmodule Mxpanel.HTTPClient.HackneyAdapter do
   mix deps.clean mxpanel
   mix compile
   ```
-
-  ## Usage
-
-  %Mxpanel.Client{http_client: {Mxpanel.HTTPClient.HackneyAdapter, []}, token: "token"}
 
   """
   @behaviour Mxpanel.HTTPClient

--- a/lib/mxpanel/people.ex
+++ b/lib/mxpanel/people.ex
@@ -1,0 +1,154 @@
+defmodule Mxpanel.People do
+  @moduledoc """
+  Functions to manipulate user profiles.
+
+  ## Shared Options
+
+  All of the functions in this module accept the following options:
+
+  #{NimbleOptions.docs(Mxpanel.People.UpdateEvent.shared_options_schema())}
+
+  """
+
+  alias Mxpanel.API
+  alias Mxpanel.Client
+  alias Mxpanel.People.UpdateEvent
+
+  @doc """
+  Sets properties for a profile identified by its `distinct_id`.
+  If the profile does not exist, it creates it with these properties.
+  If it does exist, it sets the properties to these values, overwriting existing values.
+
+      properties = %{"Address" => "1313 Mockingbird Lane", "Birthday" => "1948-01-01"}
+      Mxpanel.People.set(client, "13793", properties)
+
+  """
+  @spec set(Client.t(), String.t(), map(), Keyword.t()) :: :ok | {:error, term()}
+  def set(%Client{} = client, distinct_id, properties, opts \\ [])
+      when is_binary(distinct_id) and is_map(properties) and is_list(opts) do
+    data =
+      distinct_id
+      |> UpdateEvent.new("$set", properties, opts)
+      |> UpdateEvent.serialize(client.token)
+
+    API.request(client, "/engage", data)
+  end
+
+  @doc """
+  Works just like `set/4` except it will not overwrite existing property values. This is useful for properties like "First login date".
+
+      properties = %{"First login date" => "2013-04-01T13:20:00"}
+      Mxpanel.People.set_once(client, "13793", properties)
+
+  """
+  @spec set_once(Client.t(), String.t(), map(), Keyword.t()) :: :ok | {:error, term()}
+  def set_once(%Client{} = client, distinct_id, properties, opts \\ [])
+      when is_binary(distinct_id) and is_map(properties) and is_list(opts) do
+    data =
+      distinct_id
+      |> UpdateEvent.new("$set_once", properties, opts)
+      |> UpdateEvent.serialize(client.token)
+
+    API.request(client, "/engage", data)
+  end
+
+  @doc """
+  Takes a list of property names, and permanently removes the properties and their values from a profile.
+
+      property_names = ["Address", "Birthday"]
+      Mxpanel.People.unset(client, "13793", property_names)
+
+  """
+  @spec unset(Client.t(), String.t(), [String.t()], Keyword.t()) :: :ok | {:error, term()}
+  def unset(%Client{} = client, distinct_id, property_names, opts \\ [])
+      when is_binary(distinct_id) and is_list(property_names) do
+    data =
+      distinct_id
+      |> UpdateEvent.new("$unset", property_names, opts)
+      |> UpdateEvent.serialize(client.token)
+
+    API.request(client, "/engage", data)
+  end
+
+  @doc """
+  Increment the value of a user profile property. When processed, the property
+  values are added to the existing values of the properties on the profile.
+  If the property is not present on the profile, the value will be added to 0.
+  It is possible to decrement by calling with negative values.
+
+      Mxpanel.People.increment(client, "13793", "Number of Logins", 12)
+
+  """
+  @spec increment(Client.t(), String.t(), String.t(), String.t(), Keyword.t()) ::
+          :ok | {:error, term()}
+  def increment(%Client{} = client, distinct_id, property, amount, opts \\ [])
+      when is_binary(distinct_id) and is_binary(property) and is_integer(amount) and
+             is_list(opts) do
+    data =
+      distinct_id
+      |> UpdateEvent.new("$add", %{property => amount}, opts)
+      |> UpdateEvent.serialize(client.token)
+
+    API.request(client, "/engage", data)
+  end
+
+  @doc """
+  Appends the item to a list associated with the corresponding property name.
+  Appending to a property that doesn't exist will result in assigning a list with one element to that property.
+
+      Mxpanel.People.append_item(client, "13793", "Items purchased", "socks")
+
+  """
+  @spec append_item(Client.t(), String.t(), String.t(), String.t(), Keyword.t()) ::
+          :ok | {:error, term()}
+  def append_item(%Client{} = client, distinct_id, property, item, opts \\ [])
+      when is_binary(distinct_id) and is_binary(property) and is_binary(item) and is_list(opts) do
+    data =
+      distinct_id
+      |> UpdateEvent.new("$append", %{property => item}, opts)
+      |> UpdateEvent.serialize(client.token)
+
+    API.request(client, "/engage", data)
+  end
+
+  @doc """
+  Removes an item from a existing list on the user profile.
+  If it does not exist, no updates are made.
+
+      Mxpanel.People.append_item(client, "13793", "Items purchased", "t-shirt")
+
+  """
+  @spec remove_item(Client.t(), String.t(), String.t(), String.t(), Keyword.t()) ::
+          :ok | {:error, term()}
+  def remove_item(%Client{} = client, distinct_id, property, item, opts \\ [])
+      when is_binary(distinct_id) and is_binary(property) and is_binary(item) and is_list(opts) do
+    data =
+      distinct_id
+      |> UpdateEvent.new("$remove", %{property => item}, opts)
+      |> UpdateEvent.serialize(client.token)
+
+    API.request(client, "/engage", data)
+  end
+
+  @doc """
+  Permanently delete the profile from Mixpanel, along with all of its properties.
+
+      Mxpanel.People.delete(client, "13793")
+
+  If you have duplicate profiles, set `ignore_alias` to true so that you
+  don't delete the original profile when trying to delete the duplicate.
+
+      Mxpanel.People.delete(client, "user@mail.com", ignore_alias: true)
+
+  """
+  @spec delete(Client.t(), String.t(), Keyword.t()) :: :ok | {:error, term()}
+  def delete(%Client{} = client, distinct_id, opts \\ [])
+      when is_binary(distinct_id) and is_list(opts) do
+    data =
+      distinct_id
+      |> UpdateEvent.new("$delete", "", opts)
+      |> UpdateEvent.serialize(client.token)
+
+    API.request(client, "/engage", data)
+  end
+end

--- a/lib/mxpanel/people/update_event.ex
+++ b/lib/mxpanel/people/update_event.ex
@@ -1,0 +1,77 @@
+defmodule Mxpanel.People.UpdateEvent do
+  @moduledoc false
+
+  defstruct [:time, :distinct_id, :operation, :properties, :modifiers]
+
+  def shared_options_schema do
+    [
+      ip: [
+        type: :string,
+        doc: "IP address to get automatic geolocation info."
+      ],
+      ignore_time: [
+        type: :boolean,
+        doc:
+          "Prevent the `$last_seen` property from incorrectly updating user profile properties with misleading timestamps in server-side Mixpanel implementations."
+      ],
+      time: [
+        type: :pos_integer,
+        doc: "Specific timestamp in seconds of the event. Defaults to `System.os_time(:second)`."
+      ]
+    ]
+  end
+
+  def delete_schema do
+    [
+      ignore_alias: [
+        type: :boolean,
+        doc: "If you have duplicate profiles, set `ignore_alias` to true so that you
+      don't delete the original profile when trying to delete the duplicate."
+      ]
+    ]
+  end
+
+  def new(distinct_id, operation, properties, opts) do
+    opts = validate_options!(operation, opts)
+
+    %__MODULE__{
+      distinct_id: distinct_id,
+      operation: operation,
+      properties: properties,
+      time: Keyword.get(opts, :time, System.os_time(:second)),
+      modifiers: build_modifiers(opts)
+    }
+  end
+
+  def serialize(%__MODULE__{} = update, token) do
+    Map.merge(
+      %{
+        "$token" => token,
+        "$distinct_id" => update.distinct_id,
+        "$time" => update.time,
+        update.operation => update.properties
+      },
+      update.modifiers
+    )
+  end
+
+  defp validate_options!(operation, opts) do
+    case NimbleOptions.validate(opts, schema(operation)) do
+      {:ok, options} ->
+        options
+
+      {:error, %NimbleOptions.ValidationError{message: message}} ->
+        raise ArgumentError, message
+    end
+  end
+
+  defp build_modifiers(opts) do
+    opts
+    |> Keyword.take([:ignore_time, :ignore_alias, :ip])
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Map.new(fn {k, v} -> {"$#{k}", v} end)
+  end
+
+  defp schema("$delete"), do: Keyword.merge(shared_options_schema(), delete_schema())
+  defp schema(_), do: shared_options_schema()
+end

--- a/test/mxpanel/api_test.exs
+++ b/test/mxpanel/api_test.exs
@@ -1,0 +1,58 @@
+defmodule Mxpanel.APITest do
+  use ExUnit.Case, async: true
+
+  alias Mxpanel.API
+  alias Mxpanel.Client
+
+  setup do
+    bypass = Bypass.open()
+
+    %{bypass: bypass}
+  end
+
+  test "success request", %{bypass: bypass} do
+    client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+
+    Bypass.expect_once(bypass, "POST", "/track", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      assert %{"data" => payload} = URI.decode_query(body)
+      decoded_payload = Base.decode64!(payload)
+
+      assert Jason.decode!(decoded_payload) == %{
+               "event" => "signup"
+             }
+
+      assert Plug.Conn.get_req_header(conn, "content-type") == [
+               "application/x-www-form-urlencoded"
+             ]
+
+      assert Plug.Conn.get_req_header(conn, "accept") == ["text/plain"]
+
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "text/plain")
+      |> Plug.Conn.resp(200, "1")
+    end)
+
+    assert API.request(client, "/track", %{"event" => "signup"}) == :ok
+  end
+
+  test "failed request", %{bypass: bypass} do
+    client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+
+    Bypass.expect_once(bypass, "POST", "/track", fn conn ->
+      Plug.Conn.resp(conn, 500, "Internal server error")
+    end)
+
+    assert {:error, %{body: "Internal server error", headers: _, status: 500}} =
+             API.request(client, "/track", %{"event" => "signup"})
+  end
+
+  test "API down", %{bypass: bypass} do
+    client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+
+    Bypass.down(bypass)
+
+    assert API.request(client, "/track", %{"event" => "signup"}) == {:error, :econnrefused}
+  end
+end

--- a/test/mxpanel/event_test.exs
+++ b/test/mxpanel/event_test.exs
@@ -3,7 +3,7 @@ defmodule Mxpanel.EventTest do
 
   alias Mxpanel.Event
 
-  describe "new/3" do
+  describe "new/4" do
     test "create new event" do
       event = Event.new("signup", "13793")
 

--- a/test/mxpanel/event_test.exs
+++ b/test/mxpanel/event_test.exs
@@ -9,6 +9,7 @@ defmodule Mxpanel.EventTest do
 
       assert event.name == "signup"
       assert event.distinct_id == "13793"
+      assert event.ip == nil
       assert is_integer(event.time)
       assert String.length(event.insert_id) == 43
       assert event.additional_properties == %{}
@@ -18,6 +19,37 @@ defmodule Mxpanel.EventTest do
       event = Event.new("signup", "13793", %{"Favourite Color" => "Red"})
 
       assert event.additional_properties == %{"Favourite Color" => "Red"}
+    end
+
+    test "custom time" do
+      time = 1234
+      event = Event.new("signup", "13793", %{}, time: time)
+
+      assert event.time == time
+      assert event.additional_properties == %{}
+    end
+
+    test "invalid time" do
+      message = "expected :time to be a positive integer, got: :invalid"
+
+      assert_raise ArgumentError, message, fn ->
+        Event.new("signup", "13793", %{}, time: :invalid)
+      end
+    end
+
+    test "custom ip" do
+      event = Event.new("signup", "13793", %{}, ip: "123.123.123.123")
+
+      assert event.ip == "123.123.123.123"
+      assert event.additional_properties == %{}
+    end
+
+    test "invalid ip" do
+      message = "expected :ip to be a string, got: :invalid"
+
+      assert_raise ArgumentError, message, fn ->
+        Event.new("signup", "13793", %{}, ip: :invalid)
+      end
     end
   end
 
@@ -35,6 +67,24 @@ defmodule Mxpanel.EventTest do
                  "$insert_id" => event.insert_id,
                  "time" => event.time,
                  "Favourite Color" => "Red"
+               }
+             }
+    end
+
+    test "serialize with custom ip" do
+      event = Event.new("signup", "13793", %{"Favourite Color" => "Red"}, ip: "72.229.28.185")
+
+      actual = Event.serialize(event, "project_token")
+
+      assert actual == %{
+               "event" => "signup",
+               "properties" => %{
+                 "distinct_id" => "13793",
+                 "token" => "project_token",
+                 "$insert_id" => event.insert_id,
+                 "time" => event.time,
+                 "Favourite Color" => "Red",
+                 "ip" => "72.229.28.185"
                }
              }
     end

--- a/test/mxpanel/people_test.exs
+++ b/test/mxpanel/people_test.exs
@@ -1,0 +1,429 @@
+defmodule Mxpanel.PeopleTest do
+  use ExUnit.Case, async: true
+
+  alias Mxpanel.Client
+  alias Mxpanel.People
+
+  setup do
+    bypass = Bypass.open()
+
+    %{bypass: bypass}
+  end
+
+  describe "set/3" do
+    test "success request", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+      properties = %{"Address" => "1313 Mockingbird Lane", "Birthday" => "1948-01-01"}
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$token"] == "project_token"
+        assert decoded_payload["$distinct_id"] == "123"
+        assert decoded_payload["$set"] == properties
+        assert is_integer(decoded_payload["$time"])
+
+        assert Map.has_key?(decoded_payload, "$ignore_time") == false
+        assert Map.has_key?(decoded_payload, "$ip") == false
+
+        assert Plug.Conn.get_req_header(conn, "content-type") == [
+                 "application/x-www-form-urlencoded"
+               ]
+
+        assert Plug.Conn.get_req_header(conn, "accept") == ["text/plain"]
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.set(client, "123", properties) == :ok
+    end
+
+    test "accept options", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+      properties = %{"Address" => "1313 Mockingbird Lane", "Birthday" => "1948-01-01"}
+      time = System.os_time(:second)
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$time"] == time
+        assert decoded_payload["$ip"] == "123.123.123.123"
+        assert decoded_payload["$ignore_time"] == true
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.set(client, "123", properties,
+               time: time,
+               ip: "123.123.123.123",
+               ignore_time: true
+             ) == :ok
+    end
+
+    test "invalid time" do
+      message = "expected :time to be a positive integer, got: :invalid"
+
+      assert_raise ArgumentError, message, fn ->
+        People.set(%Client{}, "123", %{}, time: :invalid)
+      end
+    end
+
+    test "invalid ip" do
+      message = "expected :ip to be a string, got: :invalid"
+
+      assert_raise ArgumentError, message, fn ->
+        People.set(%Client{}, "123", %{}, ip: :invalid)
+      end
+    end
+
+    test "invalid ignore_time" do
+      message = "expected :ignore_time to be a boolean, got: :invalid"
+
+      assert_raise ArgumentError, message, fn ->
+        People.set(%Client{}, "123", %{}, ignore_time: :invalid)
+      end
+    end
+  end
+
+  describe "unset/3" do
+    test "success request", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$token"] == "project_token"
+        assert decoded_payload["$distinct_id"] == "123"
+        assert decoded_payload["$unset"] == ["Days Overdue"]
+        assert is_integer(decoded_payload["$time"])
+
+        assert Map.has_key?(decoded_payload, "$ignore_time") == false
+        assert Map.has_key?(decoded_payload, "$ip") == false
+
+        assert Plug.Conn.get_req_header(conn, "content-type") == [
+                 "application/x-www-form-urlencoded"
+               ]
+
+        assert Plug.Conn.get_req_header(conn, "accept") == ["text/plain"]
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.unset(client, "123", ["Days Overdue"]) == :ok
+    end
+
+    test "accepts options", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+      time = System.os_time(:second)
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$time"] == time
+        assert decoded_payload["$ignore_time"] == true
+        assert decoded_payload["$ip"] == "123.123.123.123"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.unset(client, "123", ["Days Overdue"],
+               time: time,
+               ip: "123.123.123.123",
+               ignore_time: true
+             ) == :ok
+    end
+  end
+
+  describe "set_once/3" do
+    test "success request", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+      properties = %{"First login date" => "2013-04-01T13:20:00"}
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$token"] == "project_token"
+        assert decoded_payload["$distinct_id"] == "123"
+        assert decoded_payload["$set_once"] == properties
+        assert is_integer(decoded_payload["$time"])
+
+        assert Map.has_key?(decoded_payload, "$ignore_time") == false
+        assert Map.has_key?(decoded_payload, "$ip") == false
+
+        assert Plug.Conn.get_req_header(conn, "content-type") == [
+                 "application/x-www-form-urlencoded"
+               ]
+
+        assert Plug.Conn.get_req_header(conn, "accept") == ["text/plain"]
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.set_once(client, "123", properties) == :ok
+    end
+
+    test "accepts options", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+      properties = %{"First login date" => "2013-04-01T13:20:00"}
+      time = System.os_time(:second)
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$time"] == time
+        assert decoded_payload["$ignore_time"] == true
+        assert decoded_payload["$ip"] == "123.123.123.123"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.set_once(client, "123", properties,
+               time: time,
+               ip: "123.123.123.123",
+               ignore_time: true
+             ) == :ok
+    end
+  end
+
+  describe "increment/4" do
+    test "success request", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$token"] == "project_token"
+        assert decoded_payload["$distinct_id"] == "123"
+        assert decoded_payload["$add"] == %{"Coins Gathered" => 12}
+        assert is_integer(decoded_payload["$time"])
+
+        assert Map.has_key?(decoded_payload, "$ignore_time") == false
+        assert Map.has_key?(decoded_payload, "$ip") == false
+
+        assert Plug.Conn.get_req_header(conn, "content-type") == [
+                 "application/x-www-form-urlencoded"
+               ]
+
+        assert Plug.Conn.get_req_header(conn, "accept") == ["text/plain"]
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.increment(client, "123", "Coins Gathered", 12) == :ok
+    end
+
+    test "accepts options", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+      time = System.os_time(:second)
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$time"] == time
+        assert decoded_payload["$ignore_time"] == true
+        assert decoded_payload["$ip"] == "123.123.123.123"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.increment(client, "123", "Coins Gathered", 12,
+               time: time,
+               ip: "123.123.123.123",
+               ignore_time: true
+             ) == :ok
+    end
+  end
+
+  describe "append_item/4" do
+    test "success request", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$token"] == "project_token"
+        assert decoded_payload["$distinct_id"] == "123"
+        assert decoded_payload["$append"] == %{"Power Ups" => "Bubble Lead"}
+        assert is_integer(decoded_payload["$time"])
+
+        assert Map.has_key?(decoded_payload, "$ignore_time") == false
+        assert Map.has_key?(decoded_payload, "$ip") == false
+
+        assert Plug.Conn.get_req_header(conn, "content-type") == [
+                 "application/x-www-form-urlencoded"
+               ]
+
+        assert Plug.Conn.get_req_header(conn, "accept") == ["text/plain"]
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.append_item(client, "123", "Power Ups", "Bubble Lead") == :ok
+    end
+
+    test "accepts options", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+      time = System.os_time(:second)
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$time"] == time
+        assert decoded_payload["$ignore_time"] == true
+        assert decoded_payload["$ip"] == "123.123.123.123"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.append_item(client, "123", "Power Ups", "Bubble Lead",
+               time: time,
+               ip: "123.123.123.123",
+               ignore_time: true
+             ) == :ok
+    end
+  end
+
+  describe "remove_item/3" do
+    test "success request", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$token"] == "project_token"
+        assert decoded_payload["$distinct_id"] == "123"
+        assert decoded_payload["$remove"] == %{"Items purchased" => "socks"}
+        assert is_integer(decoded_payload["$time"])
+
+        assert Map.has_key?(decoded_payload, "$ignore_time") == false
+        assert Map.has_key?(decoded_payload, "$ip") == false
+
+        assert Plug.Conn.get_req_header(conn, "content-type") == [
+                 "application/x-www-form-urlencoded"
+               ]
+
+        assert Plug.Conn.get_req_header(conn, "accept") == ["text/plain"]
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.remove_item(client, "123", "Items purchased", "socks") == :ok
+    end
+
+    test "accepts options", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+      time = System.os_time(:second)
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$time"] == time
+        assert decoded_payload["$ignore_time"] == true
+        assert decoded_payload["$ip"] == "123.123.123.123"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.remove_item(client, "123", "Items purchased", "socks",
+               time: time,
+               ip: "123.123.123.123",
+               ignore_time: true
+             ) == :ok
+    end
+  end
+
+  describe "delete/2" do
+    test "success request", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$token"] == "project_token"
+        assert decoded_payload["$distinct_id"] == "123"
+        assert decoded_payload["$delete"] == ""
+        assert is_integer(decoded_payload["$time"])
+
+        assert Map.has_key?(decoded_payload, "$ignore_time") == false
+        assert Map.has_key?(decoded_payload, "$ip") == false
+        assert Map.has_key?(decoded_payload, "$ignore_alias") == false
+
+        assert Plug.Conn.get_req_header(conn, "content-type") == [
+                 "application/x-www-form-urlencoded"
+               ]
+
+        assert Plug.Conn.get_req_header(conn, "accept") == ["text/plain"]
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.delete(client, "123") == :ok
+    end
+
+    test "accept options", %{bypass: bypass} do
+      client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
+      time = System.os_time(:second)
+
+      Bypass.expect_once(bypass, "POST", "/engage", fn conn ->
+        decoded_payload = decode_body(conn)
+
+        assert decoded_payload["$time"] == time
+        assert decoded_payload["$ignore_time"] == true
+        assert decoded_payload["$ip"] == "123.123.123.123"
+        assert decoded_payload["$ignore_alias"] == true
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "text/plain")
+        |> Plug.Conn.resp(200, "1")
+      end)
+
+      assert People.delete(client, "123",
+               time: time,
+               ignore_time: true,
+               ip: "123.123.123.123",
+               ignore_alias: true
+             ) == :ok
+    end
+
+    test "invalid ignore_alias" do
+      message = "expected :ignore_alias to be a boolean, got: :invalid"
+
+      assert_raise ArgumentError, message, fn ->
+        People.delete(%Client{}, "123", ignore_alias: :invalid)
+      end
+    end
+  end
+
+  defp decode_body(conn) do
+    {:ok, body, _conn} = Plug.Conn.read_body(conn)
+
+    assert %{"data" => payload} = URI.decode_query(body)
+    payload |> Base.decode64!() |> Jason.decode!()
+  end
+end

--- a/test/mxpanel/people_test.exs
+++ b/test/mxpanel/people_test.exs
@@ -10,7 +10,7 @@ defmodule Mxpanel.PeopleTest do
     %{bypass: bypass}
   end
 
-  describe "set/3" do
+  describe "set/4" do
     test "success request", %{bypass: bypass} do
       client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
       properties = %{"Address" => "1313 Mockingbird Lane", "Birthday" => "1948-01-01"}
@@ -89,7 +89,7 @@ defmodule Mxpanel.PeopleTest do
     end
   end
 
-  describe "unset/3" do
+  describe "unset/4" do
     test "success request", %{bypass: bypass} do
       client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
 
@@ -142,7 +142,7 @@ defmodule Mxpanel.PeopleTest do
     end
   end
 
-  describe "set_once/3" do
+  describe "set_once/4" do
     test "success request", %{bypass: bypass} do
       client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
       properties = %{"First login date" => "2013-04-01T13:20:00"}
@@ -197,7 +197,7 @@ defmodule Mxpanel.PeopleTest do
     end
   end
 
-  describe "increment/4" do
+  describe "increment/5" do
     test "success request", %{bypass: bypass} do
       client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
 
@@ -250,7 +250,7 @@ defmodule Mxpanel.PeopleTest do
     end
   end
 
-  describe "append_item/4" do
+  describe "append_item/5" do
     test "success request", %{bypass: bypass} do
       client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
 
@@ -303,7 +303,7 @@ defmodule Mxpanel.PeopleTest do
     end
   end
 
-  describe "remove_item/3" do
+  describe "remove_item/5" do
     test "success request", %{bypass: bypass} do
       client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
 
@@ -356,7 +356,7 @@ defmodule Mxpanel.PeopleTest do
     end
   end
 
-  describe "delete/2" do
+  describe "delete/3" do
     test "success request", %{bypass: bypass} do
       client = %Client{base_url: "http://localhost:#{bypass.port}", token: "project_token"}
 


### PR DESCRIPTION
Closes #2 #4 

### Added

- Examples section to readme.
- `Mxpanel.create_alias/3`.
- `Mxpanel.People.append_item/5`.
- `Mxpanel.People.delete/3`.
- `Mxpanel.People.increment/5`.
- `Mxpanel.People.remove_item/5`.
- `Mxpanel.People.set/4`.
- `Mxpanel.People.set_once/4`.
- `Mxpanel.People.unset/4`.

## Changed

- Support custom `:ip` and `:time` for track events.
- Simplify issue template.
