### PR TITLE
Graceful shutdown of buffers

### DIFF
--- a/lib/mxpanel/batcher.ex
+++ b/lib/mxpanel/batcher.ex
@@ -60,6 +60,11 @@ defmodule Mxpanel.Batcher do
       type: :pos_integer,
       doc: "The size of the pool of event buffers. Defaults to `System.schedulers_online()`."
     ],
+    graceful_shutdown: [
+      type: :boolean,
+      doc: "Gracefully flush all in-flight messages before terminating.",
+      default: true
+    ],
     flush_interval: [
       type: :pos_integer,
       doc: "Interval in milliseconds which the event buffer are processed.",


### PR DESCRIPTION
Hi! Not sure if you're still interested in maintaining this library but I came across it and it seemed to fit my needs very nicely.

## Motivation

Closes #10 

It would be nice if we didn't drop events on e.g. restarts.

## Proposed solution

I added a `terminate` GenServer callback that invokes flush on each buffer. Test included.

In order to make a couple tests not explode when their `terminate` callbacks were run, I ended up creating a `graceful_shutdown` flag which is on by default, but can be disabled for those tests. I'm not super happy with that solution, but I couldn't get `Mox.stub` to work for those tests either.

If you have a better testing strategy, I'd be happy to investigate.
